### PR TITLE
Start server for local default

### DIFF
--- a/proxy.py
+++ b/proxy.py
@@ -86,4 +86,7 @@ async def server_error(request, exc):
 
 if __name__ == '__main__':
     import uvicorn
+    if state.get("type") == "local":
+        start_local_server(os.path.join(
+            config.model_folder, state['filename']))
     uvicorn.run(app, host="0.0.0.0", port=5001)


### PR DESCRIPTION
Previously, if the default model was local, the local server would not be started unless the model was explicitly selected via `set_target`. This is now not required anymore.